### PR TITLE
Allow passing options only via the loader config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,13 @@ module.exports = {
   module: {
     loaders: [{
       test:   /\.md/,
-      loader: 'markdown-it'
+      loader: 'markdown-it',
+      options: {
+        preset: 'default',
+        typographer: true,
+        use: [subscript, superscript]
+      }
     }]
-  },
-
-  'markdown-it': {
-    preset: 'default',
-    typographer: true,
-    use: [subscript, superscript]
   }
 };
 ```
@@ -49,14 +48,13 @@ module.exports = {
   module: {
     loaders: [{
       test:   /\.md/,
-      loader: 'markdown-it'
+      loader: 'markdown-it',
+      options: {
+        preset: 'default',
+        typographer: true,
+        use: [subscript, superscript, [container, "contained"]]
+      }
     }]
-  },
-
-  'markdown-it': {
-    preset: 'default',
-    typographer: true,
-    use: [subscript, superscript, [container, "contained"]]
   }
 };
 ```

--- a/index.js
+++ b/index.js
@@ -22,8 +22,6 @@ module.exports = function (source) {
         return ''
       }
     },
-    this['markdown-it'],
-    this.options['markdown-it'],
     loaderUtils.getOptions(this)
   )
 


### PR DESCRIPTION
webpack@4 no longer allows accessing `this.options` or `this['markdown-it']`