### PR TITLE
Allow returning tokens

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,10 @@ module.exports = function (source) {
 
   var plugins = opts.use
   delete opts.use
+  var tokenize = opts.tokenize
+  delete opts.tokenize
+  var env = opts.env || {}
+  delete opts.env
 
   var parser = markdown(opts.preset, opts)
 
@@ -41,5 +45,10 @@ module.exports = function (source) {
     })
   }
 
-  return parser.render(source)
+  if (state) {
+    var tokens = this.parse(source, env);
+    return {default: parser.renderer.render(tokens, parser.options, env), tokens}
+  } else {
+    return parser.render(source, env)
+  }
 }

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = function (source) {
     })
   }
 
-  if (state) {
+  if (tokenize) {
     var tokens = this.parse(source, env);
     return {default: parser.renderer.render(tokens, parser.options, env), tokens}
   } else {


### PR DESCRIPTION
Some markdown-it plugins inject parser tokens (like markdown-it-front-matter) that are useful to inspect after loading the content.
This change allows access to those tokens.
This also forwards env options to the parser.